### PR TITLE
Fix docker-sync conflicting with berkshelf in seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# rake-tasks-docker-sync
+
+Additional plugin for [rake-tasks-docker](https://github.com/inviqa/inviqa-rake-tasks-docker) that triggers [docker-sync](https://github.com/Eugenmayer/docker-sync) at the right points.
+
+To use, you should install `docker-sync` separately with:
+```bash
+gem install docker-sync
+```
+
+The docker-sync gem checks for updates itself, so this should be kept up to date automatically.

--- a/lib/rake-tasks-docker-sync/services.rb
+++ b/lib/rake-tasks-docker-sync/services.rb
@@ -16,24 +16,42 @@ module RakeTasksDockerSync
     end
 
     def up
-      system 'docker-sync', 'start'
+      execute do
+        system 'docker-sync', 'start'
+      end
     end
 
     def stop
-      system 'docker-sync', 'stop'
+      execute do
+        system 'docker-sync', 'stop'
+      end
     end
 
     def down
-      system 'docker-sync', 'clean'
+      execute do
+        system 'docker-sync', 'clean'
+      end
     end
 
     def exec(user, command)
       @services.each do |service|
-        system 'docker', 'exec', '--user', user, service, command
+        execute do
+          system 'docker', 'exec', '--user', user, service, command
+        end
       end
     end
 
     protected
+
+    def execute(&block)
+      if defined?(Bundler)
+        Bundler.with_clean_env do
+          yield block
+        end
+      else
+        yield block
+      end
+    end
 
     def containers
       `#{@services.map { |service| "docker ps -q -f 'name=#{service}'" }.join(' && ')}`.split("\n")

--- a/lib/rake-tasks-docker-sync/version.rb
+++ b/lib/rake-tasks-docker-sync/version.rb
@@ -1,3 +1,3 @@
 module RakeTasksDockerSync
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end

--- a/lib/rake-tasks-docker-sync/version.rb
+++ b/lib/rake-tasks-docker-sync/version.rb
@@ -1,3 +1,3 @@
 module RakeTasksDockerSync
-  VERSION = '0.3.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/rake-tasks-docker-sync.gemspec
+++ b/rake-tasks-docker-sync.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'docker-sync'
   spec.add_dependency 'rake', '>= 10.0', '<= 13'
   spec.add_dependency 'rake-tasks-docker', '>= 0.2'
 


### PR DESCRIPTION
The latest docker-sync version has bumped `thor` to `~> 0.20.0` but other tools that we rely on like berkshelf use `~> 0.19.0` which means we can't install it.

Externalise the docker-sync install to avoid this dependency conflict.